### PR TITLE
Portability fixes for macOS + Homebrew

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -64,7 +64,7 @@ AC_CHECK_HEADERS( \
 [ \
 pthread.h \
 string.h stdlib.h stdio.h sys/stat.h unistd.h stdarg.h sys/ioctl.h arpa/inet.h \
-locale.h malloc.h sys/socket.h netdb.h signal.h ctype.h \
+locale.h sys/socket.h netdb.h signal.h ctype.h \
 algorithm string list vector queue stack sstream \
 expat.h \
 ] ,  , [AC_MSG_ERROR([Couldn't find some headers])] )

--- a/src/resultdom.h
+++ b/src/resultdom.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <list>
 #include <stdlib.h>
-
+#include <clocale>
 
 class Item //элемент дерева данных (например <disk_usage>1129827635.000000</disk_usage>)
 {

--- a/src/tui-main.cpp
+++ b/src/tui-main.cpp
@@ -21,7 +21,7 @@
 #else
     #include <curses.h>
 #endif
-#include <malloc.h>
+#include <cstdlib>
 #include "kclog.h"
 #include "mainprog.h"
 


### PR DESCRIPTION
These two commits fix some minor portability issues with building on Darwin/macOS:

- malloc() lives in stdlib.h under POSIX; malloc.h is a non-standard header.
- LC_* definitions require locale.h to be explicitly imported on Darwin.

In making these changes, I used the standards-conforming #include <c*> syntax instead of #include <*.h>, although I doubt it makes any real difference in practice.

With these two commits and Homebrew's openssl and ncurses installed, the build succeeds and the program appears to work normally.

`autoconf`
`./configure --without-gnutls --without-ncursesw CPPFLAGS="-I/usr/local/opt/openssl/include -I/usr/local/opt/ncurses/include" CXXFLAGS="-I/usr/local/opt/openssl/include -I/usr/local/opt/ncurses/include" LDFLAGS="-L/usr/local/opt/ncurses/lib -L/usr/local/opt/openssl/lib"`
`make`