### PR TITLE
Add memory and received time

### DIFF
--- a/src/mainwin.cpp
+++ b/src/mainwin.cpp
@@ -50,6 +50,7 @@ MainWin::MainWin(NRect rect/*, Config* cfg*/) : NGroup(rect)
     colname.push_back("    rec");
     colname.push_back("    d/l");
     colname.push_back("  application                   ");
+    colname.push_back("swap size ");
     colname.push_back("  task");
     tablheader = new NStaticText(NRect(1, rect.cols -2-(INFPANWIDTH)-1, 1, 1));
     tablheader->setstring(getcolorpair(COLOR_CYAN,-1) | A_BOLD,"  #  state    done%%  project               est d/l   task");

--- a/src/mainwin.cpp
+++ b/src/mainwin.cpp
@@ -47,6 +47,7 @@ MainWin::MainWin(NRect rect/*, Config* cfg*/) : NGroup(rect)
     colname.push_back("   done%%");
     colname.push_back("  project             ");
     colname.push_back("    est");
+    colname.push_back("    rec");
     colname.push_back("    d/l");
     colname.push_back("  application                   ");
     colname.push_back("  task");

--- a/src/taskinfowin.cpp
+++ b/src/taskinfowin.cpp
@@ -149,11 +149,11 @@ std::string raw2hr (Item* item)
 	if (d < 1)
 	{
 		d *= 1024;
-		result << std::setprecision(4) << d << "Mb";
+		result << std::setprecision(4) << d << "MB";
 	}
 	else
 	{
-		result << std::setprecision(4) << d << "Gb";
+		result << std::setprecision(4) << d << "GB";
 	}
     }
     return result.str();

--- a/src/taskinfowin.cpp
+++ b/src/taskinfowin.cpp
@@ -138,6 +138,24 @@ std::string raw2hr (Item* item)
 	    }
 	}
     }
+    if
+    (
+	!strcmp(item->getname(), "swap_size") ||
+	!strcmp(item->getname(), "working_set_size") ||
+	!strcmp(item->getname(), "working_set_size_smoothed")
+    )
+    {
+	double d = item->getdvalue()/(1024*1024*1024);
+	if (d < 1)
+	{
+		d *= 1024;
+		result << std::setprecision(3) << d << "Mb";
+	}
+	else
+	{
+		result << std::setprecision(3) << d << "Gb";
+	}
+    }
     return result.str();
 }
 

--- a/src/taskinfowin.cpp
+++ b/src/taskinfowin.cpp
@@ -149,11 +149,11 @@ std::string raw2hr (Item* item)
 	if (d < 1)
 	{
 		d *= 1024;
-		result << std::setprecision(3) << d << "Mb";
+		result << std::setprecision(4) << d << "Mb";
 	}
 	else
 	{
-		result << std::setprecision(3) << d << "Gb";
+		result << std::setprecision(4) << d << "Gb";
 	}
     }
     return result.str();

--- a/src/taskwin.cpp
+++ b/src/taskwin.cpp
@@ -552,6 +552,7 @@ void TaskWin::updatedata() //обновить данные с сервера
 			}
 			else
 			{
+			    d /= 1024;
 			    snprintf(buf, sizeof(buf),"%.3f%s", d,"GB");
 			}
 			cs->append(attr2," %6s", buf);

--- a/src/taskwin.cpp
+++ b/src/taskwin.cpp
@@ -537,9 +537,31 @@ void TaskWin::updatedata() //обновить данные с сервера
 			mbstrtrunc(buf,30);
 		    cs->append(attr,"  %-30s", buf);
 		}
-		//колонка 8 имя задачи
+		//колонка 8 swap size
 		if(iscolvisible(column++))
-		    cs->append(attr,"  %s", name->getsvalue()); 
+		{
+		    Item* swap_size = (*it)->findItem("swap_size");
+		    int attr2 = attr;
+		    if (swap_size != NULL)
+		    {
+			double d = swap_size->getdvalue()/(1024*1024);
+			char buf[64];
+			if (d <= 1024)
+			{
+			    snprintf(buf, sizeof(buf),"%.1f%s", d,"MB");
+			}
+			else
+			{
+			    snprintf(buf, sizeof(buf),"%.3f%s", d,"GB");
+			}
+			cs->append(attr2," %6s", buf);
+		    }
+		    else
+			cs->append(attr," %6s ", " - ");
+		}
+		//колонка 9 имя задачи
+		if(iscolvisible(column++))
+		    cs->append(attr,"   %s", name->getsvalue());
 		//добавляем сформированную строку и поле данных с именем задачи (для селектора)
 		//addstring(strdup(name->getsvalue()),cs);
 		addstring(new TaskInfo(name->getsvalue(),(*it)->findItem("project_url")->getsvalue()), cs);

--- a/src/taskwin.cpp
+++ b/src/taskwin.cpp
@@ -487,7 +487,21 @@ void TaskWin::updatedata() //обновить данные с сервера
 		    else
 			cs->append(attr2," %6s", "?");
 		}
-		//колонка 5 время дедлайн
+		//колонка 5 received time column
+		if(iscolvisible(column++))
+		{
+		    Item* received_time = (*it)->findItem("received_time");
+		    int attr2 = attr;
+		    if (received_time != NULL)
+		    {
+			double dtime = received_time->getdvalue();
+			double beforedl = time(NULL) - dtime; //число секунд до дедлайна
+			cs->append(attr2," %6s", gethumanreadabletimestr(beforedl).c_str());
+		    }
+		    else
+			cs->append(attr," %6s", "?");
+		}
+		//колонка 6 время дедлайн
 		if(iscolvisible(column++))
 		{
 		    Item* report_deadline = (*it)->findItem("report_deadline");
@@ -503,7 +517,7 @@ void TaskWin::updatedata() //обновить данные с сервера
 		    else
 			cs->append(attr2," %6s", "?");
 		}
-		//колонка 6 имя приложения
+		//колонка 7 имя приложения
 		if(iscolvisible(column++))
 		{
 		    char buf[256];
@@ -523,7 +537,7 @@ void TaskWin::updatedata() //обновить данные с сервера
 			mbstrtrunc(buf,30);
 		    cs->append(attr,"  %-30s", buf);
 		}
-		//колонка 7 имя задачи
+		//колонка 8 имя задачи
 		if(iscolvisible(column++))
 		    cs->append(attr,"  %s", name->getsvalue()); 
 		//добавляем сформированную строку и поле данных с именем задачи (для селектора)

--- a/src/topmenu.cpp
+++ b/src/topmenu.cpp
@@ -47,7 +47,7 @@
 #define M_ALL_TASKS			"All tasks"
 #define M_HIDE_DONE			"Hide done tasks"
 #define M_ACTIVE_ONLY			"Active tasks only"
-#define M_UNSORTED			"Unsorted tasks list"
+#define M_SORT_BY_REC			"Sort by received time"
 #define M_SORT_BY_STATE			"Sort by state"
 #define M_SORT_BY_DONE			"Sort by done %"
 #define M_SORT_BY_PROJECT		"Sort by project name"
@@ -298,7 +298,7 @@ ViewSubMenu::ViewSubMenu(NRect rect/*, Config* cfg*/) : NMenu(rect)
 	    taskssortmode = tasks_sort_mode->getivalue();
 	}
     }
-    additem(M_UNSORTED,         (taskssortmode == 0) ? "(*)" : "( )");
+    additem(M_SORT_BY_REC,      (taskssortmode == 0) ? "(*)" : "( )");
     additem(M_SORT_BY_STATE,    (taskssortmode == 1) ? "(*)" : "( )");
     additem(M_SORT_BY_DONE,     (taskssortmode == 2) ? "(*)" : "( )");
     additem(M_SORT_BY_PROJECT,  (taskssortmode == 3) ? "(*)" : "( )");
@@ -352,7 +352,7 @@ bool ViewSubMenu::action()
 	return true;
     }
 
-    if ( strcmp(item_name(current_item(menu)), M_UNSORTED) == 0 )
+    if ( strcmp(item_name(current_item(menu)), M_SORT_BY_REC) == 0 )
     {
 	putevent(new TuiEvent(evSORTMODECH, 0));
 	return true;

--- a/src/topmenu.cpp
+++ b/src/topmenu.cpp
@@ -41,6 +41,7 @@
 #define M_VIEW_DONE			"Percent done column"
 #define M_VIEW_PROJECT			"Project name column"
 #define M_VIEW_ESTIMATE			"Estimate time column"
+#define M_VIEW_RECEIVED			"Received time column"
 #define M_VIEW_DEADLINE			"Deadline time column"
 #define M_VIEW_APPNAME			"Application name column"
 #define M_VIEW_TASKNAME			"Task name column"
@@ -270,6 +271,7 @@ ViewSubMenu::ViewSubMenu(NRect rect/*, Config* cfg*/) : NMenu(rect)
     additem(M_VIEW_DONE, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
     additem(M_VIEW_PROJECT, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
     additem(M_VIEW_ESTIMATE, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
+    additem(M_VIEW_RECEIVED, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
     additem(M_VIEW_DEADLINE, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
     additem(M_VIEW_APPNAME, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
     additem(M_VIEW_TASKNAME, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");

--- a/src/topmenu.cpp
+++ b/src/topmenu.cpp
@@ -44,6 +44,7 @@
 #define M_VIEW_RECEIVED			"Received time column"
 #define M_VIEW_DEADLINE			"Deadline time column"
 #define M_VIEW_APPNAME			"Application name column"
+#define M_VIEW_SWAPSIZE			"Swap size column"
 #define M_VIEW_TASKNAME			"Task name column"
 #define M_ALL_TASKS			"All tasks"
 #define M_HIDE_DONE			"Hide done tasks"
@@ -274,6 +275,7 @@ ViewSubMenu::ViewSubMenu(NRect rect/*, Config* cfg*/) : NMenu(rect)
     additem(M_VIEW_RECEIVED, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
     additem(M_VIEW_DEADLINE, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
     additem(M_VIEW_APPNAME, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
+    additem(M_VIEW_SWAPSIZE, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
     additem(M_VIEW_TASKNAME, iscolenable(/*cfg,*/colnum++) ? "[*]" : "[ ]");
     additem("","");
     int taskslistmode = 0;


### PR DESCRIPTION
This pull request contains code which will:

1. Show the memory details (swap_size) of a given task in MB/GB, both in the main window and in the task info window. 
2. Show the received time of a given task to the main window and updates the menu text to show that being unsorted is actually sorted by received time

Let me know what you think.